### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ It must contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * ``add_annotation``

--- a/actions/add_annotation.yaml
+++ b/actions/add_annotation.yaml
@@ -1,6 +1,6 @@
 ---
 name: add_annotation
-runner_type: run-python
+runner_type: python-script
 description: Add an annotation
 enabled: true
 entry_point: add_annotation.py

--- a/actions/delete_metric.yaml
+++ b/actions/delete_metric.yaml
@@ -1,6 +1,6 @@
 ---
 name: delete_metric
-runner_type: run-python
+runner_type: python-script
 description: Delete a metric from Librato
 enabled: true
 entry_point: delete_metric.py

--- a/actions/get_metric.yaml
+++ b/actions/get_metric.yaml
@@ -1,6 +1,6 @@
 ---
 name: get_metric
-runner_type: run-python
+runner_type: python-script
 description: Retrieve a metric from Librato
 enabled: true
 entry_point: get_metric.py

--- a/actions/list_metrics.yaml
+++ b/actions/list_metrics.yaml
@@ -1,6 +1,6 @@
 ---
 name: list_metrics
-runner_type: run-python
+runner_type: python-script
 description: List all metrics setup on Librato
 enabled: true
 entry_point: list_metrics.py

--- a/actions/submit_counter.yaml
+++ b/actions/submit_counter.yaml
@@ -1,6 +1,6 @@
 ---
 name: submit_counter
-runner_type: run-python
+runner_type: python-script
 description: List all metrics setup on Librato
 enabled: true
 entry_point: submit_counter.py

--- a/actions/submit_gauge.yaml
+++ b/actions/submit_gauge.yaml
@@ -1,6 +1,6 @@
 ---
 name: submit_gauge
-runner_type: run-python
+runner_type: python-script
 description: List all metrics setup on Librato
 enabled: true
 entry_point: submit_gauge.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: librato
 name: librato
 description: Send and manage metrics with Librato
-version: 0.2.0
+version: 0.3.0
 author: James Fryman
 email: james@fryman.io


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.